### PR TITLE
Add description to tf_admin AMI variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -38,4 +38,5 @@ variable "name" {}
 
 variable "ec2_ami" {
   default = "ami-cd0f5cb6"
+  description = "Ubuntu Server 16.04 LTS (HVM)"
 }


### PR DESCRIPTION
## What
* Add description to variable `ec2_ami` in `variables.tf`

## Why
* Need a human-friendly description for AMI to simply understand which OS and version is used
