### PR TITLE
Resolve Security Group names collision between `tf_admin` and `tf_instance`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "label" {
 }
 
 resource "aws_security_group" "default" {
-  name        = "${module.label.id}"
+  name        = "${module.label.id}-ssh"
   vpc_id      = "${var.vpc_id}"
   description = "Instance default security group (only egress access is allowed)"
 

--- a/main.tf
+++ b/main.tf
@@ -9,9 +9,9 @@ module "label" {
 }
 
 resource "aws_security_group" "default" {
-  name        = "${module.label.id}-public_ssh"
+  name        = "${module.label.id}-ssh"
   vpc_id      = "${var.vpc_id}"
-  description = "Instance default security group (only egress access is allowed)"
+  description = "Allowed SSH access from any source"
 
   tags {
     Name      = "${module.label.id}"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "label" {
 }
 
 resource "aws_security_group" "default" {
-  name        = "${module.label.id}-ssh"
+  name        = "${module.label.id}-public_ssh"
   vpc_id      = "${var.vpc_id}"
   description = "Instance default security group (only egress access is allowed)"
 

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "label" {
 resource "aws_security_group" "default" {
   name        = "${module.label.id}-ssh"
   vpc_id      = "${var.vpc_id}"
-  description = "Allowed SSH access from any source"
+  description = "Allow SSH access from any source"
 
   tags {
     Name      = "${module.label.id}"


### PR DESCRIPTION
## what
* Fixed name collision of security group in `tf_admin` with `tf_instance`

## why
* Name collision of security group in `tf_admin` with `tf_instance`