### PR TITLE
Changed protocol name to `tcp` in the default security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "default" {
   }
 
   ingress {
-    protocol  = "ssh"
+    protocol  = "tcp"
     from_port = 0
     to_port   = 22
 
@@ -73,4 +73,3 @@ module "dns" {
   ttl       = 60
   records   = ["${module.instance.public_hostname}"]
 }
-


### PR DESCRIPTION
## What
* Changed protocol name to `tcp` in the default security group

## Why
* Wrong protocol name

## Plan
![image](https://user-images.githubusercontent.com/1134449/30151473-42407f8c-93b8-11e7-98a2-c8d5b4ffb52f.png)
![image](https://user-images.githubusercontent.com/1134449/30151489-584a62ca-93b8-11e7-85c5-f77baead6504.png)
