### PR TITLE
Update `terraform-aws-ec2-admin-server` to use the latest `terraform-aws-ec2-instance`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ That is why `terraform-aws-route53-cluster-zone` should be implemented in `root`
 
 ### This module depends on the next modules:
 
-* [tf_label](https://github.com/cloudposse/tf_label)
+* [terraform-null-label](https://github.com/cloudposse/terraform-null-label)
 * [tf_github_authorized_keys](https://github.com/cloudposse/tf_github_authorized_keys)
 * [tf_ansible](https://github.com/cloudposse/tf_ansible)
 * [terraform-aws-route53-cluster-hostname](https://github.com/cloudposse/terraform-aws-route53-cluster-hostname)
@@ -61,9 +61,9 @@ resource "aws_ami_from_instance" "example" {
 
 |  Name                        |  Default       |  Description                                                                                       | Required|
 |:-----------------------------|:--------------:|:---------------------------------------------------------------------------------------------------|:-------:|
-| `namespace`                  | `global`       | Namespace (e.g. `cp` or `cloudposse`) - required for `tf_label` module                             | Yes     |
-| `stage`                      | `default`      | Stage (e.g. `prod`, `dev`, `staging` - required for `tf_label` module                              | Yes     |
-| `name`                       | `admin`        | Name  (e.g. `bastion` or `db`) - required for `tf_label` module                                    | Yes     |
+| `namespace`                  | `global`       | Namespace (e.g. `cp` or `cloudposse`) - required for `terraform-null-label` module                 | Yes     |
+| `stage`                      | `default`      | Stage (e.g. `prod`, `dev`, `staging` - required for `terraform-null-label` module                  | Yes     |
+| `name`                       | `admin`        | Name  (e.g. `bastion` or `db`) - required for `terraform-null-label` module                        | Yes     |
 | `ec2_ami`                    | `ami-cd0f5cb6` | By default it is an AMI provided by Amazon with Ubuntu 16.04                                       | No      |
 | `ssh_key_pair`               | ``             | SSH key pair to be provisioned on instance                                                         | Yes     |
 | `github_api_token`           | ``             | GitHub API token                                                                                   | Yes     |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tf_admin
 
-Terraform Module for providing a server capable of running admin tasks. Use `tf_admin` to create and manage an admin instance.
+Terraform Module for providing a server capable of running admin tasks. Use `terraform-aws-ec2-admin-server` to create and manage an admin instance.
 
 ## Usage
 
@@ -10,7 +10,7 @@ Include this repository as a module in your existing terraform code:
 
 ```terraform
 module "admin_tier" {
-  source                      = "git::https://github.com/cloudposse/tf_admin.git?ref=master"
+  source                      = "git::https://github.com/cloudposse/terraform-aws-ec2-admin-server.git?ref=master"
   ansible_playbook            = "${var.ansible_playbook}"
   ansible_arguments           = "${var.ansible_arguments}"
   ansible_envs                = "${var.ansible_envs}"
@@ -32,11 +32,11 @@ module "admin_tier" {
 
 ### Module `tf_domain`
 
-Module `tf_admin` requires another module to be used additionally - `tf_domain`.
+Module `terraform-aws-ec2-admin-server` requires another module to be used additionally - `tf_domain`.
 
-`tf_admin` uses `tf_hostname` to create a DNS record for created host. `tf_hostname` module needs `zone_id` parameter as an input, and this parameter actually is an output from `tf_domain`.
+`terraform-aws-ec2-admin-server` uses `tf_hostname` to create a DNS record for created host. `tf_hostname` module needs `zone_id` parameter as an input, and this parameter actually is an output from `tf_domain`.
 
-That is why `tf_domain` should be implemented in `root` TF manifest when we need `tf_admin`.
+That is why `terraform-aws-route53-cluster-zone` should be implemented in `root` TF manifest when we need `terraform-aws-ec2-admin-server`.
 
 
 ### This module depends on the next modules:
@@ -44,8 +44,8 @@ That is why `tf_domain` should be implemented in `root` TF manifest when we need
 * [tf_label](https://github.com/cloudposse/tf_label)
 * [tf_github_authorized_keys](https://github.com/cloudposse/tf_github_authorized_keys)
 * [tf_ansible](https://github.com/cloudposse/tf_ansible)
-* [tf_hostname](https://github.com/cloudposse/tf_hostname)
-* [tf_domain](https://github.com/cloudposse/tf_domain) (not directly, but `tf_hostname` need child `zone_id`)
+* [terraform-aws-route53-cluster-hostname](https://github.com/cloudposse/terraform-aws-route53-cluster-hostname)
+* [terraform-aws-route53-cluster-zone](https://github.com/cloudposse/terraform-aws-route53-cluster-zone) (not directly, but `terraform-aws-route53-cluster-hostname` need child `zone_id`)
 
 It is necessary to run `terraform get` to download those modules.
 
@@ -59,24 +59,24 @@ resource "aws_ami_from_instance" "example" {
 
 ## Variables
 
-|  Name                        |  Default       |  Description                                                              | Required|
-|:-----------------------------|:--------------:|:--------------------------------------------------------------------------|:-------:|
-| `namespace`                  | `global`       | Namespace (e.g. `cp` or `cloudposse`) - required for `tf_label` module    | Yes     |
-| `stage`                      | `default`      | Stage (e.g. `prod`, `dev`, `staging` - required for `tf_label` module     | Yes     |
-| `name`                       | `admin`        | Name  (e.g. `bastion` or `db`) - required for `tf_label` module           | Yes     |
-| `ec2_ami`                    | `ami-cd0f5cb6` | By default it is an AMI provided by Amazon with Ubuntu 16.04              | No      |
-| `ssh_key_pair`               | ``             | SSH key pair to be provisioned on instance                                | Yes     |
-| `github_api_token`           | ``             | GitHub API token                                                          | Yes     |
-| `github_organization`        | ``             | GitHub organization name                                                  | Yes     |
-| `github_team`                | ``             | GitHub team                                                               | Yes     |
-| `ansible_playbook`           | ``             | Path to the playbook - required for `tf_ansible` (e.g. `./admin_tier.yml`)| Yes     |
-| `ansible_arguments`          | []             | List of ansible arguments (e.g. `["--user=ubuntu"]`)                      | No      |
-| `ansible_envs`               | []             | List of ansible envs (e.g. `["ansible_pass=${var.ansible_password}"]`)    | Yes     |
-| `instance_type`              | `t2.micro`     | The type of the creating instance (e.g. `t2.micro`)                       | No      |
-| `vpc_id`                     | ``             | The id of the VPC that the creating instance security group belongs to    | Yes     |
-| `security_groups`            | []             | List of Security Group IDs allowed to connect to creating instance        | Yes     |
-| `subnets`                    | []             | List of VPC Subnet IDs creating instance launched in                      | Yes     |
-| `zone_id`                    | ``             | ID of the domain zone to use - is a result of tf_domain output            | Yes     |
+|  Name                        |  Default       |  Description                                                                                       | Required|
+|:-----------------------------|:--------------:|:---------------------------------------------------------------------------------------------------|:-------:|
+| `namespace`                  | `global`       | Namespace (e.g. `cp` or `cloudposse`) - required for `tf_label` module                             | Yes     |
+| `stage`                      | `default`      | Stage (e.g. `prod`, `dev`, `staging` - required for `tf_label` module                              | Yes     |
+| `name`                       | `admin`        | Name  (e.g. `bastion` or `db`) - required for `tf_label` module                                    | Yes     |
+| `ec2_ami`                    | `ami-cd0f5cb6` | By default it is an AMI provided by Amazon with Ubuntu 16.04                                       | No      |
+| `ssh_key_pair`               | ``             | SSH key pair to be provisioned on instance                                                         | Yes     |
+| `github_api_token`           | ``             | GitHub API token                                                                                   | Yes     |
+| `github_organization`        | ``             | GitHub organization name                                                                           | Yes     |
+| `github_team`                | ``             | GitHub team                                                                                        | Yes     |
+| `ansible_playbook`           | ``             | Path to the playbook - required for `tf_ansible` (e.g. `./admin_tier.yml`)                         | Yes     |
+| `ansible_arguments`          | []             | List of ansible arguments (e.g. `["--user=ubuntu"]`)                                               | No      |
+| `ansible_envs`               | []             | List of ansible envs (e.g. `["ansible_pass=${var.ansible_password}"]`)                             | Yes     |
+| `instance_type`              | `t2.micro`     | The type of the creating instance (e.g. `t2.micro`)                                                | No      |
+| `vpc_id`                     | ``             | The id of the VPC that the creating instance security group belongs to                             | Yes     |
+| `security_groups`            | []             | List of Security Group IDs allowed to connect to creating instance                                 | Yes     |
+| `subnets`                    | []             | List of VPC Subnet IDs creating instance launched in                                               | Yes     |
+| `zone_id`                    | ``             | ID of the domain zone to use - is a result of terraform-aws-route53-cluster-zone output            | Yes     |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ That is why `terraform-aws-route53-cluster-zone` should be implemented in `root`
 ### This module depends on the next modules:
 
 * [terraform-null-label](https://github.com/cloudposse/terraform-null-label)
-* [tf_github_authorized_keys](https://github.com/cloudposse/tf_github_authorized_keys)
-* [tf_ansible](https://github.com/cloudposse/tf_ansible)
+* [terraform-aws-ubuntu-github-authorized-keys-user-data](https://github.com/cloudposse/terraform-aws-ubuntu-github-authorized-keys-user-data)
+* [terraform-null-ansible](https://github.com/cloudposse/terraform-null-ansible)
 * [terraform-aws-route53-cluster-hostname](https://github.com/cloudposse/terraform-aws-route53-cluster-hostname)
 * [terraform-aws-route53-cluster-zone](https://github.com/cloudposse/terraform-aws-route53-cluster-zone) (not directly, but `terraform-aws-route53-cluster-hostname` need child `zone_id`)
 
@@ -69,7 +69,7 @@ resource "aws_ami_from_instance" "example" {
 | `github_api_token`           | ``             | GitHub API token                                                                                   | Yes     |
 | `github_organization`        | ``             | GitHub organization name                                                                           | Yes     |
 | `github_team`                | ``             | GitHub team                                                                                        | Yes     |
-| `ansible_playbook`           | ``             | Path to the playbook - required for `tf_ansible` (e.g. `./admin_tier.yml`)                         | Yes     |
+| `ansible_playbook`           | ``             | Path to the playbook - required for `terraform-null-ansible` (e.g. `./admin_tier.yml`)             | Yes     |
 | `ansible_arguments`          | []             | List of ansible arguments (e.g. `["--user=ubuntu"]`)                                               | No      |
 | `ansible_envs`               | []             | List of ansible envs (e.g. `["ansible_pass=${var.ansible_password}"]`)                             | Yes     |
 | `instance_type`              | `t2.micro`     | The type of the creating instance (e.g. `t2.micro`)                                                | No      |

--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ module "admin_tier" {
   namespace                   = "${var.namespace}"
   stage                       = "${var.stage}"
   subnets                     = ["${var.subnets}"]
-  zone_id                     = "${module.tf_domain.zone_id}"
+  zone_id                     = "${module.terraform-aws-route53-cluster-zone.zone_id}"
   security_groups             = ["${var.security_groups}"]
 }
 
 ```
 
-### Module `tf_domain`
+### Module `terraform-aws-route53-cluster-zone`
 
-Module `terraform-aws-ec2-admin-server` requires another module to be used additionally - `tf_domain`.
+Module `terraform-aws-ec2-admin-server` requires another module to be used additionally - `terraform-aws-route53-cluster-zone`.
 
-`terraform-aws-ec2-admin-server` uses `tf_hostname` to create a DNS record for created host. `tf_hostname` module needs `zone_id` parameter as an input, and this parameter actually is an output from `tf_domain`.
+`terraform-aws-ec2-admin-server` uses `tf_hostname` to create a DNS record for created host. `tf_hostname` module needs `zone_id` parameter as an input, and this parameter actually is an output from `terraform-aws-route53-cluster-zone`.
 
 That is why `terraform-aws-route53-cluster-zone` should be implemented in `root` TF manifest when we need `terraform-aws-ec2-admin-server`.
 

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 
 # Apply the tf_label module for this resource
 module "label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.1.0"
+  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.1.0"
   namespace = "${var.namespace}"
   stage     = "${var.stage}"
   name      = "${var.name}"
@@ -46,7 +46,7 @@ resource "aws_security_group" "default" {
 
 # Using tf_instance module
 module "instance" {
-  source              = "git::https://github.com/cloudposse/tf_instance.git?ref=tags/0.3.5"
+  source              = "git::https://github.com/cloudposse/terraform-aws-ec2-instance.git?ref=tags/0.3.8"
   namespace           = "${var.namespace}"
   name                = "${var.name}"
   stage               = "${var.stage}"
@@ -67,7 +67,7 @@ module "instance" {
 }
 
 module "dns" {
-  source    = "git::https://github.com/cloudposse/tf_hostname.git?ref=tags/0.1.0"
+  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.1.0"
   namespace = "${var.namespace}"
   name      = "${var.name}"
   stage     = "${var.stage}"


### PR DESCRIPTION
## What
* Update `terraform-aws-ec2-admin-server` to use the latest `terraform-aws-ec2-instance`

## Why
* Fix outputs to be a string values into `terraform-aws-ec2-instance`

## Plan
![image](https://user-images.githubusercontent.com/1134449/31337869-d465e922-ad05-11e7-8d06-f356acff90c9.png)
